### PR TITLE
Remove swift-java internal definition

### DIFF
--- a/Sources/SwiftJavaJNICore/JavaType.swift
+++ b/Sources/SwiftJavaJNICore/JavaType.swift
@@ -80,9 +80,3 @@ extension JavaType {
     }
   }
 }
-
-extension JavaType {
-  public static var _OutSwiftGenericInstance: JavaType {
-    .class(package: "org.swift.swiftkit.core", name: "_OutSwiftGenericInstance")
-  }
-}


### PR DESCRIPTION
https://github.com/swiftlang/swift-java/pull/648#discussion_r2992558781

Move a definition that was accidentally ported to jni-core.


I identified a similar case with `JavaExceptionType.integerOverflow`.
However, since it proved difficult to remove this one simply, I have left it as-is for the time being.