### PR TITLE
Make nested arrays a bit safer, don't count on null arrays

### DIFF
--- a/Sources/SwiftJavaJNICore/BridgedValues/JavaValue+Array.swift
+++ b/Sources/SwiftJavaJNICore/BridgedValues/JavaValue+Array.swift
@@ -21,13 +21,13 @@ extension Array: JavaValue where Element: JavaValue {
   public static var javaType: JavaType { .array(Element.javaType) }
 
   public init(fromJNI value: JNIType, in environment: JNIEnvironment) {
-    let jniCount = environment.interface.GetArrayLength(environment, value)
-    let count = Int(jniCount)
-
     guard let value else {
       self = []
       return
     }
+
+    let jniCount = environment.interface.GetArrayLength(environment, value)
+    let count = Int(jniCount)
 
     // Fast path for byte types: Since the memory layout of `jbyte` (Int8) and UInt8/Int8 is identical,
     // we can rebind the memory and fill it directly without creating an intermediate array.

--- a/Tests/SwiftJavaJNICoreTests/JavaEnvironmentTests.swift
+++ b/Tests/SwiftJavaJNICoreTests/JavaEnvironmentTests.swift
@@ -183,6 +183,25 @@ struct JavaEnvironmentTests {
   }
 
   @Test(.enabled(if: isSupportedPlatform))
+  func fromJNI_nestedArrayWithNullInnerElement() throws {
+    let env = try JavaVirtualMachine.shared().environment()
+
+    let makeOuter = [[UInt8]].jniNewArray(in: env)
+    let outer = makeOuter(env, 3)
+
+    let inner0 = [UInt8(1)].getJNIValue(in: env)
+    let inner1nil: jobject? = nil // oh no!
+    let inner2 = [UInt8(2), UInt8(3)].getJNIValue(in: env)
+
+    env.interface.SetObjectArrayElement(env, outer, 0, inner0)
+    env.interface.SetObjectArrayElement(env, outer, 1, inner1nil)
+    env.interface.SetObjectArrayElement(env, outer, 2, inner2)
+
+    let result = [[UInt8]](fromJNI: outer, in: env) // avoid NPE on the inner1nil, just count as 0 length
+    #expect(result == [[0x01], [], [0x02, 0x03]])
+  }
+
+  @Test(.enabled(if: isSupportedPlatform))
   func getJNIValue_nestedInt32Array() throws {
     let env = try JavaVirtualMachine.shared().environment()
 


### PR DESCRIPTION
Maybe a little over protective, but I think this is nice to do since crashes across languages are so painful to debug -- and i've hit this myself just now.

Move referring to value below the guarded unwrap