### PR TITLE
Build SwiftJavaJNICore as a dynamic library product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,7 @@ let package = Package(
   products: [
     .library(
       name: "SwiftJavaJNICore",
+      type: .dynamic,
       targets: ["SwiftJavaJNICore"]
     )
   ],


### PR DESCRIPTION
For the same reason as https://github.com/swiftlang/swift-java/issues/419#issuecomment-3639640831, we need to build the `SwiftJavaJNICore` product as `.dynamic` in order to avoid double-inclusion of the library when is comes in via a diamond dependency.

The new `swiftbuild` system helpfully [flags](https://github.com/swiftlang/swift-build/blob/21d2bb760b6522488be15852b940c57891790da5/Sources/SWBTaskConstruction/ProductPlanning/ProductPlan.swift#L842) this upfront at build time (rather than just resulting in eventual runtime crashes and/or inexplicable behavior):

> error: Swift package product 'SwiftJavaJNICore-product' is linked as a static library by 'SkipAndroidBridge-product' and 'SwiftJNI-product'. This will result in duplication of library code.

We may want to also add a `SwiftJavaJNICoreStatic` target, like what was done in https://github.com/swiftlang/swift-java/pull/756.